### PR TITLE
Enhance Signup Form: Validate Mobile Number Uniqueness with +91 Prefix

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -26,7 +26,10 @@ class UserController extends Controller
             'username' => 'required|string|max:255|unique:users,username',
             'email' => 'required|email|unique:users,email|max:255',
             'password' => 'required|min:3|confirmed',
+            'mobile_number' => 'required|string|digits:10|unique:users,mobile_number', // Added validation for mobile_number
         ]);
+
+        $mobile_number = '+91' . $request->mobile_number;
 
         // Create a new user
         User::create([
@@ -34,10 +37,21 @@ class UserController extends Controller
             'username' => $request->username, // Save username
             'email' => $request->email,
             'password' => Hash::make($request->password), // Hash the password
+            'mobile_number' => $mobile_number, // Save mobile number
         ]);
 
         // Redirect or show success message
         return redirect('register')->with('success', 'User registered successfully!');
-        
+
+    }
+
+    public function checkUniqueness(Request $request)
+    {
+        $field = $request->field;
+        $value = $request->value;
+
+        $exists = User::where($field, $value)->exists();
+
+        return response()->json(['unique' => !$exists]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
         'email',
         'password',
         'remember_token',
+        'mobile_number',
     ];
 
     protected $hidden = [

--- a/resources/views/admin/manageusers/manageusers.blade.php
+++ b/resources/views/admin/manageusers/manageusers.blade.php
@@ -21,7 +21,7 @@
 
         setTimeout(function () {
             window.location.href = "{{ route('admin.manageuser') }}"; // Replace 'login' with your login route name
-        }, 100); // 600 milliseconds = 0.6 seconds
+        }, 600); // 600 milliseconds = 0.6 seconds
     </script>
 @endif
 <!-- Export Button -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,7 @@ Route::get('register', function () {
 
 
 Route::post('signup', [UserController::class, 'store'])->name('register.store');
+Route::post('check-uniqueness', [UserController::class, 'checkUniqueness'])->name('check.uniqueness');
 
 Route::get('explore', function () {
     return view('courses.courses');


### PR DESCRIPTION
This PR introduces improvements to the signup form and its validation logic. Specifically, the changes ensure mobile number uniqueness is correctly validated when the user enters a 10-digit number without the +91 prefix. The following updates have been made:

Client-Side Script Enhancements:

Mobile numbers entered by users are automatically prefixed with +91 before sending them to the server for uniqueness validation.
Ensures consistent formatting between client-side input and server-side data storage.
Dynamic Validation for All Fields:

The uniqueness check for username, email, and mobile_number happens in real-time.
Appropriate error messages are displayed if a field is already taken.
Submit Button Logic:

The "Signup" button remains disabled until all validation conditions (password strength, field uniqueness, and password confirmation) are satisfied.
User Experience Improvements:

Error messages for invalid or non-unique fields are clear and user-friendly.
Password strength requirements are displayed dynamically with color-coded feedback.
HTML and UX Updates:

Updated mobile number input field to include a placeholder guiding users to enter numbers without the +91 prefix.