### PR TITLE
🔒 Implement OTP Verification for Admin Login

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,6 +1,10 @@
 <?php
 namespace App\Http\Controllers;
 use Illuminate\Http\Request;
+use App\Models\Admin;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use App\Mail\AdminOtpMail;
 use Illuminate\Support\Facades\Auth;
 
 class AuthController extends Controller
@@ -9,39 +13,65 @@ class AuthController extends Controller
     {
         // Validate the incoming request
         $request->validate([
-            'username' => 'required|string', // Validate username instead of email
+            'username' => 'required|string',
             'password' => 'required',
         ]);
 
-        // Check credentials using username
         $credentials = $request->only('username', 'password');
-        $remember = $request->has('remember'); // Check "Remember Me" option
-
-        // Check if the user is in the 'admin' table
-        $admin = \App\Models\Admin::where('username', $credentials['username'])->first();
+        $admin = Admin::where('username', $credentials['username'])->first();
 
         if ($admin) {
-            // If the username exists in the admin table, verify the password
-            if (\Illuminate\Support\Facades\Hash::check($credentials['password'], $admin->password)) {
-                // Log the admin in (you can use a custom guard for admins if needed)
-                Auth::guard('admin')->login($admin, $request->has('remember'));
+            if (Hash::check($credentials['password'], $admin->password)) {
+                // Generate OTP
+                $otp = random_int(100000, 999999);
 
-                // Redirect to the admin dashboard
-                return redirect()->route('admin.dashboard')->with('success', 'Welcome Admin!');
+                // Store OTP in session (or in DB if required)
+                session(['admin_otp' => $otp, 'admin_id' => $admin->id]);
+
+                // Send OTP email
+                Mail::to($admin->email)->send(new AdminOtpMail($otp));
+
+                // Redirect to OTP verification page
+                return redirect()->route('admin.verifyOtp')->with('success', 'OTP sent to your email.');
             }
 
-            // Invalid password for admin
             return redirect()->back()->withErrors(['password' => 'Invalid credentials for admin.']);
         }
-        // Attempt login
-        if (Auth::attempt(['username' => $credentials['username'], 'password' => $credentials['password']], $remember)) {
-            // Successful login
+
+        // Normal user login
+        if (Auth::attempt($credentials, $request->has('remember'))) {
             return redirect()->route('users.dashboard')->with('success', 'You have logged in successfully!');
         }
 
-        // Login failed
         return redirect()->back()->withErrors(['username' => 'Invalid credentials, please try again.']);
     }
+
+    public function verifyOtp(Request $request)
+    {
+        $request->validate([
+            'otp' => 'required|digits:6',
+        ]);
+
+        $otp = session('admin_otp');
+        $adminId = session('admin_id');
+
+        if ($request->otp == $otp && $adminId) {
+            $admin = Admin::where('id', $adminId)->first(); // Ensure it returns a single instance
+
+            if ($admin) {
+                Auth::guard('admin')->login($admin);
+
+                // Clear session OTP
+                session()->forget(['admin_otp', 'admin_id']);
+
+                return redirect()->route('admin.dashboard')->with('success', 'Welcome Admin!');
+            }
+        }
+
+        return redirect()->back()->withErrors(['otp' => 'Invalid OTP, please try again.']);
+    }
+
+
 
     public function logout(Request $request)
     {

--- a/app/Mail/AdminOtpMail.php
+++ b/app/Mail/AdminOtpMail.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class AdminOtpMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $otp;
+
+    public function __construct($otp)
+    {
+        $this->otp = $otp;
+    }
+
+    public function build()
+    {
+        return $this->subject('Admin Login OTP')->view('emails.adminOtp')->with(['otp' => $this->otp]);
+    }
+}

--- a/resources/views/admin/verifyOtp.blade.php
+++ b/resources/views/admin/verifyOtp.blade.php
@@ -1,0 +1,6 @@
+<form action="{{ route('admin.verifyOtp.post') }}" method="POST">
+    @csrf
+    <label for="otp">Enter OTP:</label>
+    <input type="text" name="otp" required>
+    <button type="submit">Verify</button>
+</form>

--- a/resources/views/emails/adminOtp.blade.php
+++ b/resources/views/emails/adminOtp.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Admin OTP</title>
+</head>
+<body>
+    <p>Hello Admin,</p>
+    <p>Your OTP for login is: <strong>{{ $otp }}</strong></p>
+    <p>This OTP is valid for 10 minutes.</p>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,12 @@ Route::get('login', function () {
     return view('auth.login');
 })->name('login');
 
+Route::get('/admin/verify-otp', function () {
+    return view('admin.verifyOtp'); // Create this view
+})->name('admin.verifyOtp');
+
+Route::post('/admin/verify-otp', [AuthController::class, 'verifyOtp'])->name('admin.verifyOtp.post');
+
 
 // Handle Login Submission
 Route::post('login', [AuthController::class, 'login'])->name('login.perform');


### PR DESCRIPTION
**This PR enhances the admin login process by implementing an OTP-based authentication system for added security.**

**Changes include:**

- Generate a 6-digit OTP when an admin logs in.
- Store OTP in the session (admin_otp, admin_id).
- Send OTP to the admin's email using Mail::to().
- Redirect admin to an OTP verification page (/admin/verify-otp).
- Verify OTP before granting access to the admin dashboard.
- Clear OTP session after successful authentication.

**Why this change?**
->Enhances security by adding an additional layer of authentication.
->Prevents unauthorized access to admin accounts.